### PR TITLE
Support file descriptor store messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,9 @@ repository = "https://github.com/lnicola/sd-notify"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+fdstore = ["dep:sendfd"]
+
+[dependencies]
+sendfd = { version = "0.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,12 @@ pub enum NotifyState<'a> {
     /// Tells the service manager to store attached file descriptors.
     #[cfg(feature = "fdstore")]
     FdStore,
+    /// Tells the service manager to remove stored file descriptors.
+    #[cfg(feature = "fdstore")]
+    FdStoreRemove,
+    /// Tells the service manager to use this name for the attached file descriptor.
+    #[cfg(feature = "fdstore")]
+    FdName(&'a str),
     /// Custom state.
     Custom(&'a str),
 }
@@ -84,6 +90,10 @@ impl Display for NotifyState<'_> {
             NotifyState::ExtendTimeoutUsec(usec) => write!(f, "EXTEND_TIMEOUT_USEC={}", usec),
             #[cfg(feature = "fdstore")]
             NotifyState::FdStore => write!(f, "FDSTORE=1"),
+            #[cfg(feature = "fdstore")]
+            NotifyState::FdStoreRemove => write!(f, "FDSTOREREMOVE=1"),
+            #[cfg(feature = "fdstore")]
+            NotifyState::FdName(name) => write!(f, "FDNAME={}", name),
             NotifyState::Custom(state) => write!(f, "{}", state),
         }
     }
@@ -238,16 +248,18 @@ fn connect_notify_socket(unset_env: bool) -> io::Result<Option<UnixDatagram>> {
 /// let socket = sd_notify::listen_fds().map(|mut fds| fds.next().expect("missing fd"));
 /// ```
 pub fn listen_fds() -> io::Result<impl Iterator<Item = RawFd>> {
-    struct Guard;
+    listen_fds_internal(true)
+}
 
-    impl Drop for Guard {
-        fn drop(&mut self) {
-            env::remove_var("LISTEN_PID");
-            env::remove_var("LISTEN_FDS");
-        }
-    }
-
-    let _guard = Guard;
+fn listen_fds_internal(unset_env: bool) -> io::Result<impl ExactSizeIterator<Item = RawFd>> {
+    let _guard1 = UnsetEnvGuard {
+        name: "LISTEN_PID",
+        unset_env,
+    };
+    let _guard2 = UnsetEnvGuard {
+        name: "LISTEN_FDS",
+        unset_env,
+    };
 
     let listen_pid = if let Ok(pid) = env::var("LISTEN_PID") {
         pid
@@ -283,6 +295,87 @@ pub fn listen_fds() -> io::Result<impl Iterator<Item = RawFd>> {
     let last = RawFd::try_from(last).map_err(|_| overflow())?;
     let listen_fds = SD_LISTEN_FDS_START as RawFd..last;
     Ok(listen_fds)
+}
+
+/// Checks for file descriptors passed by the service manager for socket
+/// activation.
+///
+/// The function returns an iterator over file descriptors, starting from
+/// `SD_LISTEN_FDS_START`. The number of descriptors is obtained from the
+/// `LISTEN_FDS` environment variable.
+///
+/// If the `unset_env` parameter is set, the `LISTEN_PID`, `LISTEN_FDS` and
+/// `LISTEN_FDNAMES` environment variable will be unset before returning.
+/// Child processes will not see the fdnames passed to this process. This is
+/// usually not necessary, as a process should only use the `LISTEN_FDS`
+/// variable if it is the PID given in `LISTEN_PID`.
+///
+/// Before returning, the file descriptors are set as `O_CLOEXEC`.
+///
+/// See [`sd_listen_fds_with_names(3)`][sd_listen_fds_with_names] for details.
+///
+/// [sd_listen_fds_with_names]: https://www.freedesktop.org/software/systemd/man/sd_listen_fds.html
+///
+/// # Example
+///
+/// ```no_run
+/// let socket = sd_notify::listen_fds().map(|mut fds| fds.next().expect("missing fd"));
+/// ```
+pub fn listen_fds_with_names(
+    unset_env: bool,
+) -> io::Result<impl ExactSizeIterator<Item = (RawFd, String)>> {
+    let listen_fds = listen_fds_internal(unset_env)?;
+    let _guard = UnsetEnvGuard {
+        name: "LISTEN_FDNAMES",
+        unset_env,
+    };
+    zip_fds_with_names(listen_fds, env::var("LISTEN_FDNAMES").ok())
+}
+
+/// Internal helper that is independent of listen_fds function, for testing purposes.
+fn zip_fds_with_names(
+    listen_fds: impl ExactSizeIterator<Item = RawFd>,
+    listen_fdnames: Option<String>,
+) -> io::Result<impl ExactSizeIterator<Item = (RawFd, String)>> {
+    let listen_fdnames = if let Some(names) = listen_fdnames {
+        // systemd shouldn't provide an empty fdname element. However if it does, the
+        // sd_listen_fds_with_names function will return an empty string for that fd,
+        // as in the following C example:
+        //
+        // void main() {
+        //  char **names;
+        //  setenv("LISTEN_FDNAMES", "x::z", 1);
+        //  int n = sd_listen_fds_with_names(0, &names);
+        //  assert(*names[1] == 0);
+        // }
+        names.split(':').map(|x| x.to_owned()).collect::<Vec<_>>()
+    } else {
+        let mut names = vec![];
+        names.resize(listen_fds.len(), "unknown".to_string());
+        names
+    };
+
+    if listen_fdnames.len() == listen_fds.len() {
+        Ok(listen_fds.zip(listen_fdnames))
+    } else {
+        Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "invalid LISTEN_FDNAMES",
+        ))
+    }
+}
+
+struct UnsetEnvGuard {
+    name: &'static str,
+    unset_env: bool,
+}
+
+impl Drop for UnsetEnvGuard {
+    fn drop(&mut self) {
+        if self.unset_env {
+            env::remove_var(self.name);
+        }
+    }
 }
 
 fn fd_cloexec(fd: u32) -> io::Result<()> {
@@ -357,6 +450,7 @@ mod tests {
     use super::NotifyState;
     use std::env;
     use std::fs;
+    use std::os::fd::RawFd;
     use std::os::unix::net::UnixDatagram;
     use std::path::PathBuf;
     use std::process;
@@ -427,6 +521,55 @@ mod tests {
         assert!(super::listen_fds().is_err());
         assert!(env::var_os("LISTEN_PID").is_none());
         assert!(env::var_os("LISTEN_FDS").is_none());
+    }
+
+    #[test]
+    fn listen_fds_with_names() {
+        assert_eq!(
+            super::zip_fds_with_names(3 as RawFd..4 as RawFd, Some("omelette".to_string()))
+                .unwrap()
+                .collect::<Vec<_>>(),
+            vec![(3 as RawFd, "omelette".to_string())]
+        );
+
+        assert_eq!(
+            super::zip_fds_with_names(
+                3 as RawFd..5 as RawFd,
+                Some("omelette:baguette".to_string())
+            )
+            .unwrap()
+            .collect::<Vec<_>>(),
+            vec![
+                (3 as RawFd, "omelette".to_string()),
+                (4 as RawFd, "baguette".to_string())
+            ]
+        );
+
+        // LISTEN_FDNAMES is cleared
+        assert_eq!(
+            super::zip_fds_with_names(3 as RawFd..4 as RawFd, None)
+                .unwrap()
+                .next(),
+            Some((3 as RawFd, "unknown".to_string()))
+        );
+
+        // LISTEN_FDNAMES is cleared, every fd should have the name "unknown"
+        assert_eq!(
+            super::zip_fds_with_names(3 as RawFd..5 as RawFd, None)
+                .unwrap()
+                .collect::<Vec<_>>(),
+            vec![
+                (3 as RawFd, "unknown".to_string()),
+                (4 as RawFd, "unknown".to_string())
+            ],
+        );
+
+        // Raise an error if LISTEN_FDNAMES has a different number of entries as fds
+        assert!(super::zip_fds_with_names(
+            3 as RawFd..6 as RawFd,
+            Some("omelette:baguette".to_string())
+        )
+        .is_err());
     }
 
     #[test]


### PR DESCRIPTION
Support for systemd's file descriptor store is added using new NotifyState variants and a new `notify_with_fds` function, which passes file descriptors over the NOTIFY_SOCKET. The capability is gated behind a "fdstore" feature to avoid adding dependencies that were not previously required, and no existing API is touched except for the feature-gated NotifyState enum.

As stored file descriptors can be named, you should be able to retrieve file descriptors by those names. This is implemented via the new `listen_fds_with_names` function, and is also useful if you are using socket activation.
