### PR TITLE
Fix the FD_CLOEXEC bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.2] - 2024-04-22
+
+### Changed
+
+- `FD_CLOEXEC` bit mask definition fixed. The wrong definition effectively lead to `close-on-exec` flag not being set for all `listen_fds`.
+
 ## [0.4.1] - 2022-08-31
 
 ### Changed

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -5,6 +5,6 @@ extern "C" {
 pub const F_GETFD: i32 = 1;
 pub const F_SETFD: i32 = 2;
 
-pub const FD_CLOEXEC: i32 = 2;
+pub const FD_CLOEXEC: i32 = 1;
 
 pub const EBADF: i32 = 9;


### PR DESCRIPTION
FD_CLOEXEC is not a bit position. It's a bit mask already.

See the definition in the kernel:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/asm-generic/fcntl.h

and the use of that constant in:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/fcntl.c

The current code in sd-notify is a no-op. Bit 1 is not looked at by the kernel. sd-notify does not touch bit 0.

Fix this by changing the mask.