### PR TITLE
Change `watchdog_enabled` to use `Duration`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A lightweight crate for sending `systemd` service state notifications.
 ## Quick start
 
 ```rust
-let _ = sd_notify::notify(false, &[NotifyState::Ready]);
+let _ = sd_notify::notify(&[NotifyState::Ready]);
 ```
 
 ## Releases

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A lightweight crate for sending `systemd` service state notifications.
 ## Quick start
 
 ```rust
-let _ = sd_notify::notify(true, &[NotifyState::Ready]);
+let _ = sd_notify::notify(false, &[NotifyState::Ready]);
 ```
 
 ## Releases

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! ```no_run
 //! # use sd_notify::NotifyState;
 //! #
-//! let _ = sd_notify::notify(true, &[NotifyState::Ready]);
+//! let _ = sd_notify::notify(false, &[NotifyState::Ready]);
 //! ```
 
 use std::convert::TryFrom;
@@ -139,6 +139,7 @@ pub fn booted() -> io::Result<bool> {
 
 /// Sends the service manager a list of state changes.
 ///
+/// The `unset_env` parameter should generally not be set, see the Safety section.
 /// If the `unset_env` parameter is set, the `NOTIFY_SOCKET` environment variable
 /// will be unset before returning. Further calls to `sd_notify` will fail, but
 /// child processes will no longer inherit the variable.
@@ -157,12 +158,18 @@ pub fn booted() -> io::Result<bool> {
 ///
 /// If you wish to send file descriptors, use the `notify_with_fds` function.
 ///
+/// # Safety
+///
+/// Although this function is not marked as `unsafe`, it is `unsafe` to call
+/// with `unset_env` set to true. See the documentation on
+/// [std::env::remove_var] for further information on this unsafety.
+///
 /// # Example
 ///
 /// ```no_run
 /// # use sd_notify::NotifyState;
 /// #
-/// let _ = sd_notify::notify(true, &[NotifyState::Ready]);
+/// let _ = sd_notify::notify(false, &[NotifyState::Ready]);
 /// ```
 pub fn notify(unset_env: bool, state: &[NotifyState]) -> io::Result<()> {
     let mut msg = String::new();
@@ -182,6 +189,7 @@ pub fn notify(unset_env: bool, state: &[NotifyState]) -> io::Result<()> {
 
 /// Sends the service manager a list of state changes with file descriptors.
 ///
+/// The `unset_env` parameter should generally not be set, see the Safety section.
 /// If the `unset_env` parameter is set, the `NOTIFY_SOCKET` environment variable
 /// will be unset before returning. Further calls to `sd_notify` will fail, but
 /// child processes will no longer inherit the variable.
@@ -197,6 +205,12 @@ pub fn notify(unset_env: bool, state: &[NotifyState]) -> io::Result<()> {
 /// sending notifications on behalf of other processes, doesn't send credentials,
 /// and does not increase the send buffer size. It's still useful, though, in
 /// usual situations.
+///
+/// # Safety
+///
+/// Although this function is not marked as `unsafe`, it is `unsafe` to call
+/// with `unset_env` set to true. See the documentation on
+/// [std::env::remove_var] for further information on this unsafety.
 ///
 /// # Example
 ///
@@ -328,6 +342,7 @@ fn listen_fds_internal(unset_env: bool) -> io::Result<impl ExactSizeIterator<Ite
 /// `SD_LISTEN_FDS_START`. The number of descriptors is obtained from the
 /// `LISTEN_FDS` environment variable.
 ///
+/// The `unset_env` parameter should generally not be set, see the Safety section.
 /// If the `unset_env` parameter is set, the `LISTEN_PID`, `LISTEN_FDS` and
 /// `LISTEN_FDNAMES` environment variable will be unset before returning.
 /// Child processes will not see the fdnames passed to this process. This is
@@ -339,6 +354,12 @@ fn listen_fds_internal(unset_env: bool) -> io::Result<impl ExactSizeIterator<Ite
 /// See [`sd_listen_fds_with_names(3)`][sd_listen_fds_with_names] for details.
 ///
 /// [sd_listen_fds_with_names]: https://www.freedesktop.org/software/systemd/man/sd_listen_fds.html
+///
+/// # Safety
+///
+/// Although this function is not marked as `unsafe`, it is `unsafe` to call
+/// with `unset_env` set to true. See the documentation on
+/// [std::env::remove_var] for further information on this unsafety.
 ///
 /// # Example
 ///
@@ -420,6 +441,7 @@ fn fd_cloexec(fd: u32) -> io::Result<()> {
 
 /// Asks the service manager for enabled watchdog.
 ///
+/// The `unset_env` parameter should generally not be set, see the Safety section.
 /// If the `unset_env` parameter is set, the `WATCHDOG_USEC` and `WATCHDOG_PID` environment variables
 /// will be unset before returning. Further calls to `watchdog_enabled` will fail, but
 /// child processes will no longer inherit the variable.
@@ -428,6 +450,11 @@ fn fd_cloexec(fd: u32) -> io::Result<()> {
 ///
 /// [sd_watchdog_enabled]: https://www.freedesktop.org/software/systemd/man/sd_watchdog_enabled.html
 ///
+/// # Safety
+///
+/// Although this function is not marked as `unsafe`, it is `unsafe` to call
+/// with `unset_env` set to true. See the documentation on
+/// [std::env::remove_var] for further information on this unsafety.
 ///
 /// # Example
 ///

--- a/tests/listen_fds.rs
+++ b/tests/listen_fds.rs
@@ -1,0 +1,27 @@
+// There must only be one test in this file because of the thread-unsafety of
+// environment variable acceses.
+
+use std::env;
+
+#[test]
+fn listen_fds() {
+    // We are not testing the success case because `fd_cloexec` would fail.
+
+    unsafe {
+        assert!(sd_notify::listen_fds_and_unset_env().unwrap().next().is_none());
+
+        env::set_var("LISTEN_PID", "1");
+        env::set_var("LISTEN_FDS", "1");
+        assert!(sd_notify::listen_fds_and_unset_env().unwrap().next().is_none());
+    }
+    assert!(env::var_os("LISTEN_PID").is_none());
+    assert!(env::var_os("LISTEN_FDS").is_none());
+
+    unsafe {
+        env::set_var("LISTEN_PID", "no way");
+        env::set_var("LISTEN_FDS", "1");
+        assert!(sd_notify::listen_fds_and_unset_env().is_err());
+    }
+    assert!(env::var_os("LISTEN_PID").is_none());
+    assert!(env::var_os("LISTEN_FDS").is_none());
+}

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -1,0 +1,58 @@
+// There must only be one test in this file because of the thread-unsafety of
+// environment variable acceses.
+
+use sd_notify::NotifyState;
+use std::env;
+use std::fs;
+use std::os::unix::net::UnixDatagram;
+use std::path::PathBuf;
+
+struct SocketHelper(PathBuf, UnixDatagram);
+
+impl SocketHelper {
+    pub fn recv_string(&self) -> String {
+        let mut buf = [0; 1024];
+        let len = self.1.recv(&mut buf).unwrap();
+        String::from_utf8(Vec::from(&buf[0..len])).unwrap()
+    }
+}
+
+impl Drop for SocketHelper {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+unsafe fn bind_socket() -> SocketHelper {
+    let path = env::temp_dir().join("sd-notify-test-sock");
+    let _ = fs::remove_file(&path);
+
+    env::set_var("NOTIFY_SOCKET", &path);
+    let sock = UnixDatagram::bind(&path).unwrap();
+    SocketHelper(path, sock)
+}
+
+#[test]
+fn notify() {
+    let s = unsafe { bind_socket() };
+
+    sd_notify::notify(&[NotifyState::Ready]).unwrap();
+    assert_eq!(s.recv_string(), "READY=1\n");
+    assert!(env::var_os("NOTIFY_SOCKET").is_some());
+
+    unsafe {
+        sd_notify::notify_and_unset_env(
+            &[
+                NotifyState::Status("Reticulating splines"),
+                NotifyState::Watchdog,
+                NotifyState::Custom("X_WORKS=1"),
+            ],
+        )
+        .unwrap();
+    }
+    assert_eq!(
+        s.recv_string(),
+        "STATUS=Reticulating splines\nWATCHDOG=1\nX_WORKS=1\n"
+    );
+    assert!(env::var_os("NOTIFY_SOCKET").is_none());
+}

--- a/tests/watchdog_enabled.rs
+++ b/tests/watchdog_enabled.rs
@@ -3,6 +3,7 @@
 
 use std::env;
 use std::process;
+use std::time::Duration;
 
 #[test]
 fn watchdog_enabled() {
@@ -14,11 +15,9 @@ fn watchdog_enabled() {
         env::set_var("WATCHDOG_PID", "1");
     }
 
-    let mut usec = 0;
     unsafe {
-        assert!(!sd_notify::watchdog_enabled_and_unset_env(&mut usec));
+        assert_eq!(sd_notify::watchdog_enabled_and_unset_env(), None);
     }
-    assert_eq!(usec, 0);
 
     assert!(env::var_os("WATCHDOG_USEC").is_none());
     assert!(env::var_os("WATCHDOG_PID").is_none());
@@ -29,19 +28,15 @@ fn watchdog_enabled() {
         env::set_var("WATCHDOG_PID", process::id().to_string());
     }
 
-    let mut usec = 0;
     unsafe {
-        assert!(!sd_notify::watchdog_enabled_and_unset_env(&mut usec));
+        assert_eq!(sd_notify::watchdog_enabled_and_unset_env(), None);
     }
-    assert_eq!(usec, 0);
 
     assert!(env::var_os("WATCHDOG_USEC").is_none());
     assert!(env::var_os("WATCHDOG_PID").is_none());
 
     // no usec, no pip no unset env
-    let mut usec = 0;
-    assert!(!sd_notify::watchdog_enabled(&mut usec));
-    assert_eq!(usec, 0);
+    assert_eq!(sd_notify::watchdog_enabled(), None);
 
     assert!(env::var_os("WATCHDOG_USEC").is_none());
     assert!(env::var_os("WATCHDOG_PID").is_none());
@@ -52,9 +47,7 @@ fn watchdog_enabled() {
         env::set_var("WATCHDOG_PID", process::id().to_string());
     }
 
-    let mut usec = 0;
-    assert!(sd_notify::watchdog_enabled(&mut usec));
-    assert_eq!(usec, 5);
+    assert_eq!(sd_notify::watchdog_enabled(), Some(Duration::from_micros(5)));
     assert!(env::var_os("WATCHDOG_USEC").is_some());
     assert!(env::var_os("WATCHDOG_PID").is_some());
 }

--- a/tests/watchdog_enabled.rs
+++ b/tests/watchdog_enabled.rs
@@ -1,0 +1,60 @@
+// There must only be one test in this file because of the thread-unsafety of
+// environment variable acceses.
+
+use std::env;
+use std::process;
+
+#[test]
+fn watchdog_enabled() {
+    // test original logic: https://github.com/systemd/systemd/blob/f3376ee8fa28aab3f7edfad1ddfbcceca5bc841c/src/libsystemd/sd-daemon/sd-daemon.c#L632
+
+    // invalid pid and unset env
+    unsafe {
+        env::set_var("WATCHDOG_USEC", "5");
+        env::set_var("WATCHDOG_PID", "1");
+    }
+
+    let mut usec = 0;
+    unsafe {
+        assert!(!sd_notify::watchdog_enabled_and_unset_env(&mut usec));
+    }
+    assert_eq!(usec, 0);
+
+    assert!(env::var_os("WATCHDOG_USEC").is_none());
+    assert!(env::var_os("WATCHDOG_PID").is_none());
+
+    // invalid usec and no unset env
+    unsafe {
+        env::set_var("WATCHDOG_USEC", "invalid-usec");
+        env::set_var("WATCHDOG_PID", process::id().to_string());
+    }
+
+    let mut usec = 0;
+    unsafe {
+        assert!(!sd_notify::watchdog_enabled_and_unset_env(&mut usec));
+    }
+    assert_eq!(usec, 0);
+
+    assert!(env::var_os("WATCHDOG_USEC").is_none());
+    assert!(env::var_os("WATCHDOG_PID").is_none());
+
+    // no usec, no pip no unset env
+    let mut usec = 0;
+    assert!(!sd_notify::watchdog_enabled(&mut usec));
+    assert_eq!(usec, 0);
+
+    assert!(env::var_os("WATCHDOG_USEC").is_none());
+    assert!(env::var_os("WATCHDOG_PID").is_none());
+
+    // valid pip
+    unsafe {
+        env::set_var("WATCHDOG_USEC", "5");
+        env::set_var("WATCHDOG_PID", process::id().to_string());
+    }
+
+    let mut usec = 0;
+    assert!(sd_notify::watchdog_enabled(&mut usec));
+    assert_eq!(usec, 5);
+    assert!(env::var_os("WATCHDOG_USEC").is_some());
+    assert!(env::var_os("WATCHDOG_PID").is_some());
+}


### PR DESCRIPTION
Also return the value via the return value instead of via an out parameter.

Based on top of #13 because it'll likely conflict otherwise.

For reviewing, just look at the last commit.